### PR TITLE
Possible bugfix: newlines not being sent

### DIFF
--- a/sources/ConnectWorker.cpp
+++ b/sources/ConnectWorker.cpp
@@ -206,7 +206,7 @@ void sendToArduino(float received, std::string prefix, const char *portName) {
   auto *const c_string = new char[input_string.size() + 1];
   std::copy(input_string.begin(), input_string.end(), c_string);
   c_string[input_string.size()] = '\n';
-  arduino.writeSerialPort(c_string, input_string.length());
+  arduino.writeSerialPort(c_string, input_string.length() + 1);
   delete[] c_string;
 }
 void sendCharToArduino(const char *received, std::string prefix,
@@ -223,7 +223,7 @@ void sendCharToArduino(const char *received, std::string prefix,
   std::copy(input_string.begin(), input_string.end(), c_string);
   c_string[input_string.size()] = '\n';
 
-  arduino.writeSerialPort(c_string, input_string.length());
+  arduino.writeSerialPort(c_string, input_string.length() + 1);
   delete[] c_string;
 }
 void sendLengthToArduino(float received, std::string prefix,
@@ -266,7 +266,7 @@ void sendLengthToArduino(float received, std::string prefix,
   std::copy(input_string.begin(), input_string.end(), c_string);
   c_string[input_string.size()] = '\n';
 
-  arduino.writeSerialPort(c_string, input_string.length());
+  arduino.writeSerialPort(c_string, input_string.length() + 1);
   delete[] c_string;
 }
 
@@ -283,9 +283,9 @@ void sendFloatToArduino(float received, std::string prefix,
   std::copy(input_string.begin(), input_string.end(), c_string);
   c_string[input_string.size()] = '\n';
   if (received < 0) {
-    arduino.writeSerialPort(c_string, 7);
+    arduino.writeSerialPort(c_string, input_string.size() + 1);
   } else {
-    arduino.writeSerialPort(c_string, 6);
+    arduino.writeSerialPort(c_string, input_string.size() + 1);
   }
 
   delete[] c_string;
@@ -312,7 +312,7 @@ void sendBoolToArduino(float received, std::string prefix,
   std::copy(input_string.begin(), input_string.end(), c_string);
   c_string[input_string.size()] = '\n';
 
-  arduino.writeSerialPort(c_string, input_string.length());
+  arduino.writeSerialPort(c_string, input_string.length() + 1);
   delete[] c_string;
 }
 


### PR DESCRIPTION
Hi!

While playing with your library, I often had issues with newlines not being sent.
I was able to fix this problem:
It seems like the input_string length is passed to the writeSerialPort function, disregarding the newline character.

Disclaimer:
I did not spend a long time investigating this, and apparently it works without it for some people.
But this did seem wrong to me, and now everything is working fine with my due.

Could you please look over the changes and let me know what you think?