### PR TITLE
fix landing lights (typo in prefix)

### DIFF
--- a/outputs/outputs.json
+++ b/outputs/outputs.json
@@ -1124,7 +1124,7 @@
       "updateEvery": 0,
       "dataType": 0,
       "cbText":"(bool) Landing lights",
-      "prefix":144 ,
+      "prefix":144,
       "type":4
     }
   ],


### PR DESCRIPTION
Landing lights is not working with current version, I believe it to be a typo in this file (had a space after 144 -> "144 ,") which seems to have resulted in 44 1 and 44 0 being transmitted over serial, instead of 144 1 and 144 0