### PR TITLE
Reload ranges on start

### DIFF
--- a/Inputs/InputSwitchHandler.cpp
+++ b/Inputs/InputSwitchHandler.cpp
@@ -52,81 +52,84 @@ int oldRightBrake;
 InputEnum inputDefinitions = InputEnum();
 
 InputSwitchHandler::InputSwitchHandler() {
-  if (!settingsHandler.retrieveSetting("Ranges", "flapsmin")->isNull()) {
-    for (int i = 0; i < constants::supportedEngines; i++) {
-      QString minStr = "Engine " + QString::number(i + 1) + "Reverse";
-
-      int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
-      cout << minRange << endl;
-
-      QString idleStr = "Engine " + QString::number(i + 1) + "Idle cutoff";
-      int idleCutoff =
-          settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
-
-      QString maxStr = "Engine " + QString::number(i + 1) + "Max";
-      int maxRange = settingsHandler.retrieveSetting("Ranges", maxStr)->toInt();
-
-      enginelist[i] = Engine(minRange, idleCutoff, maxRange, i + 1);
-    }
-    for (auto &curve : curves) {
-      curve.append(coordinates(0, -16383));
-      curve.append(coordinates(250, -10000));
-      curve.append(coordinates(400, 0));
-      curve.append(coordinates(500, 0));
-      curve.append(coordinates(600, 0));
-      curve.append(coordinates(750, 10000));
-      curve.append(coordinates(1023, 16383));
-    }
-
-    if (!settingsHandler.retrieveSetting("Ranges", "maxReverseRange")
-             ->isNull()) {
-      reverseAxis =
-          settingsHandler.retrieveSetting("Ranges", "maxReverseRange")
-              ->toFloat();
-    }
-
-    for (int i = 0; i < constants::supportedMixtureLevers; i++) {
-      QString minStr = "Mixture " + QString::number(i + 1) + "Min";
-      int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
-      cout << minRange << endl;
-
-      QString idleStr = "Mixture " + QString::number(i + 1) + "Max";
-      int maxRange =
-          settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
-
-      mixtureRanges[i] = Range(minRange, maxRange);
-    }
-    for (int i = 0; i < constants::supportedPropellerLevers; i++) {
-      QString minStr = "Propeller " + QString::number(i + 1) + "Min";
-      int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
-
-      QString idleStr = "Propeller " + QString::number(i + 1) + "Max";
-      int maxRange =
-          settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
-
-      propellerRanges[i] = Range(minRange, maxRange);
-    }
-    int minFlaps =
-        settingsHandler.retrieveSetting("Ranges", "FlapsMin")->toInt();
-    int maxFlaps =
-        settingsHandler.retrieveSetting("Ranges", "FlapsMax")->toInt();
-    flapsRange = Range(minFlaps, maxFlaps);
-
-  } else if (settingsHandler.retrieveSetting("Ranges", "FlapsMin")->isNull()) {
-    for (int i = 0; i < constants::supportedEngines; i++) {
-      enginelist[i] = Engine(0, 0, 1023, i);
-    }
-    for (int i = 0; i < constants::supportedMixtureLevers; i++) {
-      mixtureRanges[i] = Range(0, 1023);
-    }
-    for (int i = 0; i < constants::supportedPropellerLevers; i++) {
-      propellerRanges[i] = Range(0, 1023);
-    }
-
-    flapsRange = Range(0, 1023);
-  }
+  setRanges();
 }
 
+void InputSwitchHandler::setRanges(){
+    if (!settingsHandler.retrieveSetting("Ranges", "FlapsMin")->isNull()) {
+        for (int i = 0; i < constants::supportedEngines; i++) {
+            QString minStr = "Engine " + QString::number(i + 1) + "Reverse";
+
+            int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
+            cout << "MIN SET"<<minRange << endl;
+
+            QString idleStr = "Engine " + QString::number(i + 1) + "Idle cutoff";
+            int idleCutoff =
+                    settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
+
+            QString maxStr = "Engine " + QString::number(i + 1) + "Max";
+            int maxRange = settingsHandler.retrieveSetting("Ranges", maxStr)->toInt();
+
+            enginelist[i] = Engine(minRange, idleCutoff, maxRange, i + 1);
+        }
+        for (auto &curve : curves) {
+            curve.append(coordinates(0, -16383));
+            curve.append(coordinates(250, -10000));
+            curve.append(coordinates(400, 0));
+            curve.append(coordinates(500, 0));
+            curve.append(coordinates(600, 0));
+            curve.append(coordinates(750, 10000));
+            curve.append(coordinates(1023, 16383));
+        }
+
+        if (!settingsHandler.retrieveSetting("Ranges", "maxReverseRange")
+                ->isNull()) {
+            reverseAxis =
+                    settingsHandler.retrieveSetting("Ranges", "maxReverseRange")
+                            ->toFloat();
+        }
+
+        for (int i = 0; i < constants::supportedMixtureLevers; i++) {
+            QString minStr = "Mixture " + QString::number(i + 1) + "Min";
+            int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
+            cout << minRange << endl;
+
+            QString idleStr = "Mixture " + QString::number(i + 1) + "Max";
+            int maxRange =
+                    settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
+
+            mixtureRanges[i] = Range(minRange, maxRange);
+        }
+        for (int i = 0; i < constants::supportedPropellerLevers; i++) {
+            QString minStr = "Propeller " + QString::number(i + 1) + "Min";
+            int minRange = settingsHandler.retrieveSetting("Ranges", minStr)->toInt();
+
+            QString idleStr = "Propeller " + QString::number(i + 1) + "Max";
+            int maxRange =
+                    settingsHandler.retrieveSetting("Ranges", idleStr)->toInt();
+
+            propellerRanges[i] = Range(minRange, maxRange);
+        }
+        int minFlaps =
+                settingsHandler.retrieveSetting("Ranges", "FlapsMin")->toInt();
+        int maxFlaps =
+                settingsHandler.retrieveSetting("Ranges", "FlapsMax")->toInt();
+        flapsRange = Range(minFlaps, maxFlaps);
+
+    } else if (settingsHandler.retrieveSetting("Ranges", "FlapsMin")->isNull()) {
+        for (int i = 0; i < constants::supportedEngines; i++) {
+            enginelist[i] = Engine(0, 0, 1023, i);
+        }
+        for (int i = 0; i < constants::supportedMixtureLevers; i++) {
+            mixtureRanges[i] = Range(0, 1023);
+        }
+        for (int i = 0; i < constants::supportedPropellerLevers; i++) {
+            propellerRanges[i] = Range(0, 1023);
+        }
+
+        flapsRange = Range(0, 1023);
+    }
+}
 UINT32 HornerScheme(UINT32 Num, UINT32 Divider, UINT32 Factor) {
   UINT32 Remainder = 0, Quotient = 0, Result = 0;
   Remainder = Num % Divider;
@@ -216,12 +219,9 @@ void InputSwitchHandler::controlYoke(int index) {
 void InputSwitchHandler::setFlaps(int index) {
   try {
     token = strtok_s(receivedString[index], " ", &next_token);
-    cout << receivedString[index] << endl;
     counter = 0;
 
     while (token != nullptr && counter < 2) {
-      cout << token << ":Counter" << counter << endl;
-
       if (token != nullptr) {
         const auto incVal = strtod(token, nullptr);
 

--- a/Inputs/InputSwitchHandler.h
+++ b/Inputs/InputSwitchHandler.h
@@ -38,7 +38,10 @@ class InputSwitchHandler {
   void setCurve(QList<coordinates> curve, int index);
 
   float reverseAxis = -23000.0;
- private slots:
+
+    void setRanges();
+
+private slots:
   SettingsHandler settingsHandler;
 
   void set_throttle_values(int index);
@@ -97,6 +100,7 @@ class InputSwitchHandler {
 
   int calibratedRange(int value, QList<coordinates> *curve);
   int calibratedRange(int value, int index);
+
 };
 
 #endif  // INPUTSWITCHHANDLER_H

--- a/Inputs/InputWorker.cpp
+++ b/Inputs/InputWorker.cpp
@@ -33,7 +33,9 @@ enum DATA_DEFINE_ID {
   DEFINITION_1 = 12,
 };
 
-InputWorker::InputWorker() {}
+InputWorker::InputWorker() {
+    handler.setRanges();
+}
 
 enum EVENT_ID {
   EVENT_SIM_START,
@@ -84,6 +86,7 @@ void InputWorker::sendWASMCommand(char cmd) {
 void InputWorker::inputEvents() {
   HRESULT hr;
   abortInput = false;
+  handler.setRanges();
   for (int i = 0; i < curveStrings.size(); i++) {
     auto rudderCurveList = new QList<coordinates>();
     if (!settingsHandler
@@ -91,7 +94,7 @@ void InputWorker::inputEvents() {
                                  QString::number(0))
              ->isNull()) {
       for (int j = 0; j < 7; j++) {
-        QString value = "axis" + QString::number(i);
+        auto value = "axis" + QString::number(i);
         auto foundAxis = settingsHandler
                              .retrieveSubSetting(curveStrings[i] + "Series",
                                                  "axis", QString::number(j))
@@ -145,13 +148,6 @@ void InputWorker::inputEvents() {
       SimConnect_AddToClientDataDefinition(
           hInputSimConnect, 12, SIMCONNECT_CLIENTDATAOFFSET_AUTO, 256, 0);
 
-      cout << "CLIENTDATA: " << hr << endl;
-
-      //      hr = SimConnect_MapClientEventToSimEvent(hInputSimConnect,
-      //      EVENT_WASM,
-      //                                               "LVAR_ACCESS.EFIS");
-
-      cout << "MAPCTOE: " << hr << endl;
       handler.connect = hInputSimConnect;
 
       handler.object = objectID;
@@ -200,4 +196,5 @@ InputWorker::~InputWorker() {
 
   condition.wakeOne();
   mutex.unlock();
+  delete this;
 }

--- a/dual/dualworker.cpp
+++ b/dual/dualworker.cpp
@@ -82,7 +82,9 @@ void sendCommand(SIMCONNECT_CLIENT_EVENT_ID eventID) {
                                  SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY);
 }
 
-DualWorker::DualWorker() {}
+DualWorker::DualWorker() {
+    dualInputHandler->setRanges();
+}
 
 void sendDualToArduino(float received, std::string prefix, int index,
                        int mode) {
@@ -318,9 +320,7 @@ void DualWorker::sendWASMCommand(char cmd) {
   puts(arrayTest);
   qDebug() << arrayTest;
   cout << arrayTest << " WASM send" << endl;
-  //  SimConnect_TransmitClientEvent(
-  //      connect, object, 2, index, SIMCONNECT_GROUP_PRIORITY_HIGHEST,
-  //      SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY);
+
 
   SimConnect_SetClientData(dualSimConnect, 1, 12,
                            SIMCONNECT_CLIENT_DATA_SET_FLAG_DEFAULT, 0, 256,
@@ -332,7 +332,7 @@ void DualWorker::addBundle(outputBundle *bundle) {
 
 void DualWorker::RadioEvents() {
   HRESULT hr;
-
+  dualInputHandler->setRanges();
   keys = settingsHandler.retrieveKeys("runningDualComs");
   int keySize = keys->size();
   int successfullyConnected = 0;

--- a/settings/formbuilder.cpp
+++ b/settings/formbuilder.cpp
@@ -663,9 +663,9 @@ QWidget *FormBuilder::generateComSelector(bool setsNeeded, int mode,
             &FormBuilder::removeComWidget);
     comRow->addWidget(removeButton);
 
-    auto autoRunCB = new ModeIndexCheckbox("auto",mode,index);
-    connect(autoRunCB, &QCheckBox::stateChanged, this, &FormBuilder::autoRunChanged);
-    comRow->addWidget(autoRunCB);
+//    auto autoRunCB = new ModeIndexCheckbox("auto",mode,index);
+//    connect(autoRunCB, &QCheckBox::stateChanged, this, &FormBuilder::autoRunChanged);
+//    comRow->addWidget(autoRunCB);
     return comSelector;
 }
 void FormBuilder::autoRunChanged(){

--- a/settings/optionsmenu.cpp
+++ b/settings/optionsmenu.cpp
@@ -121,12 +121,11 @@ optionsMenu::~optionsMenu() {
 }
 
 void optionsMenu::on_saveSettingsBtn_clicked() {
-    QLabel *communityFolderPath =
+    auto *communityFolderPath =
             this->findChild<QLabel *>("communityFolderPathLabel");
     settingsHandler.storeValue("Settings", communityFolderPath->objectName(),
                                communityFolderPath->text());
-    PathHandler pathHandler;
-    pathHandler.setCommunityFolderPath(communityFolderPath->text());
+    PathHandler::setCommunityFolderPath(communityFolderPath->text());
 
     // Checkboxes that affect the application behavior on closing / startup
     auto cbCloseToTray = this->findChild<QCheckBox *>("cbCloseToTray");

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -461,11 +461,13 @@ MainWindow::MainWindow(QWidget *parent)
     checkForUpdates(true);
     loadAutoRunState();
     settingsHandler.checkEventFilePresent();
-    if(settingsHandler.retrieveSetting("Settings","cbAutorun")->toBool()){
-        startInputs(true);
-        startDual(true);
-        startOutputs(true);
-    }
+//    if(settingsHandler.retrieveSetting("Settings","cbAutorun")->toBool()){
+//        if(advancedMode) {
+//            startInputs(true);
+//            startOutputs(true);
+//        }
+//        startDual(true);
+//    }
     this->adjustSize();
 }
 
@@ -728,7 +730,8 @@ void MainWindow::startInputs(bool autoStart) {
 
 void MainWindow::startOutputs(bool autoStart) {
     auto *widget = new QWidget();
-
+    auto *startButton =
+            ui->outWidgetContainer->findChild<QPushButton *>("2startButton");
     widget = ui->outWidgetContainer;
 
     settingsHandler.clearKeys("runningOutputComs");
@@ -742,6 +745,9 @@ void MainWindow::startOutputs(bool autoStart) {
     bool emptyDualSet = checkIfComboIsEmpty(setList);
     bool emptyDualCom = checkIfComboIsEmpty(comList);
     if (!emptyDualSet && !emptyDualCom) {
+        startButton->setChecked(true);
+        startButton->setText("Start");
+        startButton->setEnabled(false);
         QString key;
         QString setKey;
         QList<Output *> outputsToMap = QList<Output *>();
@@ -783,8 +789,7 @@ void MainWindow::startOutputs(bool autoStart) {
         outputThread.abort = false;
         outputThread.start();
     } else {
-        auto *startButton =
-                ui->outWidgetContainer->findChild<QPushButton *>("2startButton");
+
         startButton->setChecked(false);
         startButton->setText("Start");
         startButton->setEnabled(true);
@@ -809,7 +814,10 @@ void MainWindow::startOutputs(bool autoStart) {
 
 void MainWindow::startDual(bool autoStart) {
     auto *widget = new QWidget();
-
+    auto *startButton =
+            ui->dualWidgetContainer->findChild<QPushButton *>("3startButton");
+    auto *stopButton =
+            ui->dualWidgetContainer->findChild<QPushButton *>("3stopBtn");
     widget = ui->dualWidgetContainer;
     settingsHandler.clearKeys("runningDualComs");
     settingsHandler.clearKeys("runningDualSets");
@@ -826,6 +834,9 @@ void MainWindow::startDual(bool autoStart) {
         QString key;
         QString setKey;
         QList<Output *> outputsToMap;
+        startButton->setChecked(true);
+        startButton->setText("Start");
+        startButton->setEnabled(false);
         qDebug() << "sets available" << comList.size();
         dualThread.clearBundles();
 
@@ -870,6 +881,8 @@ void MainWindow::startDual(bool autoStart) {
                 }
             }
         }
+        stopButton->setChecked(false);
+        stopButton->setStyleSheet("background-color:#E20303");
 
         //    ui->stopButton->setVisible(true);
         //    QString comText = ui->outputComboBoxBase->currentText();
@@ -879,14 +892,12 @@ void MainWindow::startDual(bool autoStart) {
         dualThread.abortDual = false;
         dualThread.start();
     } else {
-        auto *startButton =
-                ui->dualWidgetContainer->findChild<QPushButton *>("3startButton");
+
         startButton->setChecked(false);
         startButton->setText("Start");
         startButton->setEnabled(true);
 
-        auto *stopButton =
-                ui->dualWidgetContainer->findChild<QPushButton *>("3stopBtn");
+
         stopButton->setChecked(true);
         stopButton->setStyleSheet("background-color:#0F4C5C");
 


### PR DESCRIPTION
Moved the range init to its own function. It is no longer needed to restart the connector.